### PR TITLE
Fixed a broken link in README that should link to the dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ class MyController
 ```
 
 [signup]: https://dashboard.nexmo.com/sign-up?utm_source=DEV_REL&utm_medium=github&utm_campaign=php-symfony-bundle
+[dashboard]: https://dashboard.nexmo.com?utm_source=DEV_REL&utm_medium=github&utm_campaign=php-symfony-bundles
 [issues]: https://github.com/nexmo/vonage-php-symfony-bundle/issues
 [pulls]: https://github.com/nexmo/vonage-php-symfony-bundle/pulls
 


### PR DESCRIPTION
There was a missing variable in the README where we are trying to link the reader to the dashboard. So the output was just: "You can then fill in the needed credentials from your [Vonage Dashboard][dashboard]."

## Description

I added the dashboard variable where the values is a link to our dashboard and have UTM tags so we know where it came from.

## Motivation and Context

The README was meant to show a link, but didn't so I added the variable it was looking for.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
